### PR TITLE
Supported calendar components checks

### DIFF
--- a/src/caldav_server_tester/checks.py
+++ b/src/caldav_server_tester/checks.py
@@ -249,6 +249,62 @@ class CheckMakeDeleteCalendar(Check):
             self.set_feature("create-calendar", False)
 
 
+class CheckSupportedComponents(Check):
+    """
+    Checks whether the server returns the supported-calendar-component-set property
+    (RFC 4791 section 5.2.3).
+
+    Strategy: if the server supports calendar creation, create a VTODO-only
+    calendar and ask for its supported component set.  If the server returns
+    exactly ["VTODO"] the property is advertised correctly (full).  If it
+    returns the RFC default (all types) the server does not advertise the
+    property (unsupported).
+
+    When calendar creation is not available we fall back to inspecting the
+    main test calendar; in that case we can only detect "full" support if the
+    server returns a strict subset of the full default list.
+    """
+
+    depends_on = {CheckMakeDeleteCalendar}
+    features_to_be_checked = {"get-supported-components"}
+
+    def _run_check(self):
+        cal = None
+        try:
+            if self.checker.features_checked.is_supported("create-calendar"):
+                cal = self.checker.principal.make_calendar(
+                    cal_id="csc_supported_components_check",
+                    name="csc_supported_components_check",
+                    supported_calendar_component_set=["VTODO"],
+                )
+                components = cal.get_supported_components()
+                ## If the server honoured the component set restriction,
+                ## the property must be present and working.
+                if set(components) == {"VTODO"}:
+                    self.set_feature("get-supported-components")
+                else:
+                    self.set_feature("get-supported-components", False)
+            elif hasattr(self.checker, "calendar"):
+                components = self.checker.calendar.get_supported_components()
+                ## When a strict subset comes back the property must be present.
+                ## If the full default comes back we cannot distinguish "full
+                ## support for all types" from "property absent".
+                if set(components) < {"VEVENT", "VTODO", "VJOURNAL"}:
+                    self.set_feature("get-supported-components")
+                else:
+                    self.set_feature("get-supported-components", "unknown")
+            else:
+                self.set_feature("get-supported-components", "unknown")
+        except Exception:
+            self.set_feature("get-supported-components", False)
+        finally:
+            if cal is not None:
+                try:
+                    cal.delete()
+                except Exception:
+                    pass
+
+
 class PrepareCalendar(Check):
     """
     This "check" doesn't check anything, but ensures the calendar has some known events

--- a/src/caldav_server_tester/checks.py
+++ b/src/caldav_server_tester/checks.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo
 from caldav.calendarobjectresource import Event, Journal, Todo
 from caldav.collection import Principal
 from caldav.davobject import DAVObject
-from caldav.lib.error import AuthorizationError, DAVError, NotFoundError, PutError, ReportError
+from caldav.lib.error import AuthorizationError, DAVError, NotFoundError, PropfindError, PutError, ReportError
 from caldav.search import CalDAVSearcher
 
 from .checks_base import Check
@@ -249,54 +249,106 @@ class CheckMakeDeleteCalendar(Check):
             self.set_feature("create-calendar", False)
 
 
-class CheckSupportedComponents(Check):
+class CheckGetSupportedComponents(Check):
     """
-    Checks whether the server returns the supported-calendar-component-set property
-    (RFC 4791 section 5.2.3).
+    Checks whether the server returns the supported-calendar-component-set
+    property (RFC 4791 section 5.2.3) by calling get_supported_components()
+    with with_fallback=False on any available calendar.
 
-    Strategy: if the server supports calendar creation, create a VTODO-only
-    calendar and ask for its supported component set.  If the server returns
-    exactly ["VTODO"] the property is advertised correctly (full).  If it
-    returns the RFC default (all types) the server does not advertise the
-    property (unsupported).
-
-    When calendar creation is not available we fall back to inspecting the
-    main test calendar; in that case we can only detect "full" support if the
-    server returns a strict subset of the full default list.
+    'full'       — server returns the property
+    'unsupported'— property absent (RFC-compliant; fallback used by the library)
+    'ungraceful' — PROPFIND for the property raised an unexpected exception
+    'unknown'    — no calendar available to test against
     """
 
     depends_on = {CheckMakeDeleteCalendar}
     features_to_be_checked = {"get-supported-components"}
 
     def _run_check(self):
+        ## Use the prepared test calendar if available, otherwise try any calendar
+        cal = getattr(self.checker, "calendar", None)
+        if cal is None:
+            cals = self.checker.principal.calendars() if self.checker.principal else []
+            if not cals:
+                self.set_feature("get-supported-components", "unknown")
+                return
+            cal = cals[0]
+        try:
+            cal.get_supported_components(with_fallback=False)
+            self.set_feature("get-supported-components")
+        except PropfindError:
+            self.set_feature("get-supported-components", False)
+        except Exception:
+            self.set_feature("get-supported-components", "ungraceful")
+
+
+class CheckCreateCalendarWithComponentSet(Check):
+    """
+    Checks whether the server honours the supported-calendar-component-set
+    restriction specified at MKCALENDAR time.
+
+    Strategy:
+    1. Create a VTODO-only calendar.
+    2. If get-supported-components is supported, verify the property on the
+       new calendar reflects the restriction (returns ["VTODO"]).
+    3. If get-supported-components is not supported, try saving a VEVENT to
+       the VTODO-only calendar.  If the server rejects it, the restriction
+       is enforced.
+
+    'full'       — restriction honoured (property correct OR wrong-type rejected)
+    'unsupported'— restriction silently ignored (wrong-type accepted, or
+                   property returns wrong value)
+    'ungraceful' — MKCALENDAR with component set specification fails
+    'unknown'    — cannot determine (e.g. calendar creation not supported)
+    """
+
+    depends_on = {CheckGetSupportedComponents, CheckMakeDeleteCalendar}
+    features_to_be_checked = {"create-calendar.with-supported-component-types"}
+
+    def _run_check(self):
+        if not self.checker.features_checked.is_supported("create-calendar"):
+            self.set_feature("create-calendar.with-supported-component-types", "unknown")
+            return
+
         cal = None
         try:
-            if self.checker.features_checked.is_supported("create-calendar"):
-                cal = self.checker.principal.make_calendar(
-                    cal_id="csc_supported_components_check",
-                    name="csc_supported_components_check",
-                    supported_calendar_component_set=["VTODO"],
-                )
-                components = cal.get_supported_components()
-                ## If the server honoured the component set restriction,
-                ## the property must be present and working.
-                if set(components) == {"VTODO"}:
-                    self.set_feature("get-supported-components")
-                else:
-                    self.set_feature("get-supported-components", False)
-            elif hasattr(self.checker, "calendar"):
-                components = self.checker.calendar.get_supported_components()
-                ## When a strict subset comes back the property must be present.
-                ## If the full default comes back we cannot distinguish "full
-                ## support for all types" from "property absent".
-                if set(components) < {"VEVENT", "VTODO", "VJOURNAL"}:
-                    self.set_feature("get-supported-components")
-                else:
-                    self.set_feature("get-supported-components", "unknown")
+            cal = self.checker.principal.make_calendar(
+                cal_id="csc_component_set_check",
+                name="csc_component_set_check",
+                supported_calendar_component_set=["VTODO"],
+            )
+
+            if self.checker.features_checked.is_supported("get-supported-components"):
+                ## Property is supported; check it reflects our restriction
+                try:
+                    components = cal.get_supported_components(with_fallback=False)
+                    if set(components) == {"VTODO"}:
+                        self.set_feature("create-calendar.with-supported-component-types")
+                    else:
+                        self.set_feature("create-calendar.with-supported-component-types", False)
+                except Exception:
+                    self.set_feature("create-calendar.with-supported-component-types", False)
             else:
-                self.set_feature("get-supported-components", "unknown")
+                ## Property not supported; probe by trying to save the wrong type
+                try:
+                    cal.save_object(
+                        Event,
+                        summary="csc component type probe",
+                        uid="csc_component_type_probe",
+                        dtstart=datetime(2000, 1, 1, 12, 0, 0, tzinfo=utc),
+                        dtend=datetime(2000, 1, 1, 13, 0, 0, tzinfo=utc),
+                    )
+                    ## Server accepted a VEVENT in a VTODO-only calendar — restriction not enforced
+                    self.set_feature("create-calendar.with-supported-component-types", False)
+                except DAVError:
+                    ## Server rejected the wrong type — restriction is enforced
+                    self.set_feature("create-calendar.with-supported-component-types")
+
+        except DAVError:
+            ## MKCALENDAR with component set failed
+            self.set_feature("create-calendar.with-supported-component-types", "ungraceful")
         except Exception:
-            self.set_feature("get-supported-components", False)
+            self.set_feature("create-calendar.with-supported-component-types", False)
         finally:
             if cal is not None:
                 try:


### PR DESCRIPTION
Related to https://github.com/python-caldav/caldav/issues/653 - test servers if they can tell what components the calendar supports, and also test weather calendar creation with a supported component set actually does anything.

Before merging, it's needed to:

* [ ] Run checks on all servers available.  Update the compatibility matrix in the caldav project.
* [ ] Rebase commits, look through descriptions and CHANGELOG
* [ ] Ensure https://github.com/python-caldav/caldav/pull/654 is pulled to master