### PR TITLE
Fix RECURRENCE-ID property name in expanded exception check

### DIFF
--- a/src/caldav_server_tester/checks.py
+++ b/src/caldav_server_tester/checks.py
@@ -1289,7 +1289,7 @@ class CheckRecurrenceSearch(Check):
             len(exception) == 1
             and exception[0].component["dtstart"] == datetime(2000, 2, 13, 12, 0, 0, tzinfo=utc)
             and exception[0].component["summary"] == "February recurrence with different summary"
-            and getattr(exception[0].component.get("RECURRENCE_ID"), "dt", None)
+            and getattr(exception[0].component.get("RECURRENCE-ID"), "dt", None)
             == datetime(2000, 2, 13, 12, tzinfo=utc),
         )
 


### PR DESCRIPTION
The icalendar library stores the property as "RECURRENCE-ID" (with hyphen), not "RECURRENCE_ID" (with underscore). Using the underscore form causes component.get() to return None, making the search.recurrences.expanded.exception check always fail.